### PR TITLE
HB-4920: Remove dispatch on main for show

### DIFF
--- a/Source/AdMobAdapterInterstitialAd.swift
+++ b/Source/AdMobAdapterInterstitialAd.swift
@@ -54,9 +54,7 @@ final class AdMobAdapterInterstitialAd: AdMobAdapterAd, PartnerAd {
         }
         showCompletion = completion
         
-        DispatchQueue.main.async {
-            ad.present(fromRootViewController: viewController)
-        }
+        ad.present(fromRootViewController: viewController)
     }
 }
 

--- a/Source/AdMobAdapterRewardedAd.swift
+++ b/Source/AdMobAdapterRewardedAd.swift
@@ -54,12 +54,10 @@ final class AdMobAdapterRewardedAd: AdMobAdapterAd, PartnerAd {
         }
         showCompletion = completion
         
-        DispatchQueue.main.async {
-            ad.present(fromRootViewController: viewController) { [weak self] in
-                guard let self = self else { return }
-                self.log(.didReward)
-                self.delegate?.didReward(self, details: [:])  ?? self.log(.delegateUnavailable)
-            }
+        ad.present(fromRootViewController: viewController) { [weak self] in
+            guard let self = self else { return }
+            self.log(.didReward)
+            self.delegate?.didReward(self, details: [:])  ?? self.log(.delegateUnavailable)
         }
     }
 }


### PR DESCRIPTION
Adapters don't need to worry about dispatching on the main thread thanks to https://github.com/ChartBoost/ios-helium-sdk/pull/862

This change is to be applied to all adapters. I made this PR to show a sample of what needs to be done everywhere.

I don't think there's much value in creating 14 PRs, but the branches are there in case anyone wants to double check.
After this PR is approved I will force push the changes on all adapters.