### PR TITLE
HB-4930: Do not dispatch loads on main thread

### DIFF
--- a/Source/AdMobAdapterBannerAd.swift
+++ b/Source/AdMobAdapterBannerAd.swift
@@ -12,13 +12,8 @@ import HeliumSdk
 class AdMobAdapterBannerAd: AdMobAdapterAd, PartnerAd {
     /// The partner ad view to display inline. E.g. a banner view.
     /// Should be nil for full-screen ads.
-    var inlineView: UIView? {
-        return self.ad
-    }
-
-    // The AdMob Ad Object
-    var ad: GADBannerView?
-
+    var inlineView: UIView?
+    
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.
     /// - parameter completion: Closure to be performed once the ad has been loaded.
@@ -34,20 +29,15 @@ class AdMobAdapterBannerAd: AdMobAdapterAd, PartnerAd {
             return
         }
         
+        let bannerView = GADBannerView(adSize: gadAdSizeFrom(cgSize: request.size))
+        bannerView.adUnitID = request.partnerPlacement
+        bannerView.isAutoloadEnabled = false
+        bannerView.delegate = self
+        bannerView.rootViewController = viewController
+        inlineView = bannerView
+        
         let adMobRequest = generateRequest()
-        let placementID = request.partnerPlacement
-
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-
-            let bannerView = GADBannerView(adSize: self.gadAdSizeFrom(cgSize: self.request.size))
-            bannerView.adUnitID = placementID
-            bannerView.isAutoloadEnabled = false
-            bannerView.delegate = self
-            bannerView.rootViewController = viewController
-            self.ad = bannerView
-            bannerView.load(adMobRequest)
-        }
+        bannerView.load(adMobRequest)
     }
     
     /// Shows a loaded ad.


### PR DESCRIPTION
Explicit dispatch on main thread is no longer necessary for banners thanks to SDK work on HB-4930.

Once this PR is approved I will push similar changes to all adapters.