### PR TITLE
Make configuration class compatible with Obj-C

### DIFF
--- a/Source/AdMobAdapterConfiguration.swift
+++ b/Source/AdMobAdapterConfiguration.swift
@@ -9,13 +9,14 @@ import Foundation
 import GoogleMobileAds
 
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
-public class AdMobAdapterConfiguration {
+@objc public class AdMobAdapterConfiguration: NSObject {
     /// Google's identifier for your test device can be found in the console output from their SDK
-    public static func setTestDeviceID(_ id: String?) {
+    @objc public static func setTestDeviceID(_ id: String?) {
         if let id = id {
             GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = [id]
         } else {
             GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = []
         }
+        print("AdMob SDK test device ID set to \(id ?? "nil")")
     }
 }


### PR DESCRIPTION
The configuration class must be Obj-C compatible for publishers to use (many of them still use Obj-C).

Once this PR is approved I will push similar changes to all adapters.