### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/AdMobAdapterBannerAd.swift
+++ b/Source/AdMobAdapterBannerAd.swift
@@ -73,7 +73,6 @@ extension AdMobAdapterBannerAd: GADBannerViewDelegate {
     }
 
     func bannerView(_ bannerView: GADBannerView, didFailToReceiveAdWithError error: Error) {
-        let error = self.error(.loadFailureUnknown, error: error)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil

--- a/Source/AdMobAdapterInterstitialAd.swift
+++ b/Source/AdMobAdapterInterstitialAd.swift
@@ -71,7 +71,7 @@ extension AdMobAdapterInterstitialAd: GADFullScreenContentDelegate {
     }
     
     func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
-        log(.showFailed(self.error(.showFailureUnknown, error: error)))
+        log(.showFailed(error))
         showCompletion?(.failure(error)) ?? log(.showResultIgnored)
         showCompletion = nil
     }

--- a/Source/AdMobAdapterRewardedAd.swift
+++ b/Source/AdMobAdapterRewardedAd.swift
@@ -75,7 +75,7 @@ extension AdMobAdapterRewardedAd: GADFullScreenContentDelegate {
     }
     
     func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
-        log(.showFailed(self.error(.showFailureUnknown, error: error)))
+        log(.showFailed(error))
         showCompletion?(.failure(error)) ?? log(.showResultIgnored)
         showCompletion = nil
     }


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.