### PR TITLE
Remove extra lines from file headers

### DIFF
--- a/Source/AdMobAdapter.swift
+++ b/Source/AdMobAdapter.swift
@@ -1,14 +1,7 @@
 // Copyright 2022-2023 Chartboost, Inc.
-// 
+//
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-
-//
-// AdMobAdapter.swift
-// ChartboostMediationAdapterAdMob
-//
-// Created by Alex Rice on 10/01/22
-//
 
 import ChartboostMediationSDK
 import Foundation

--- a/Source/AdMobAdapterAd.swift
+++ b/Source/AdMobAdapterAd.swift
@@ -1,14 +1,7 @@
 // Copyright 2022-2023 Chartboost, Inc.
-// 
+//
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-
-//
-// AdMobAdapterAd.swift
-// ChartboostMediationAdapterAdMob
-//
-// Created by Alex Rice on 10/02/22
-//
 
 import ChartboostMediationSDK
 import Foundation

--- a/Source/AdMobAdapterBannerAd.swift
+++ b/Source/AdMobAdapterBannerAd.swift
@@ -1,14 +1,7 @@
 // Copyright 2022-2023 Chartboost, Inc.
-// 
+//
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-
-//
-// AdMobAdapterInterstitialAd.swift
-// ChartboostMediationAdapterAdMob
-//
-// Created by Alex Rice on 10/02/22
-//
 
 import ChartboostMediationSDK
 import Foundation

--- a/Source/AdMobAdapterConfiguration.swift
+++ b/Source/AdMobAdapterConfiguration.swift
@@ -1,14 +1,7 @@
 // Copyright 2022-2023 Chartboost, Inc.
-// 
+//
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-
-//
-//  AdMobAdapterConfiguration.swift
-//  ChartboostMediationAdapterAdMob
-//
-//  Created by Alex Rice on 10/11/22.
-//
 
 import Foundation
 import GoogleMobileAds

--- a/Source/AdMobAdapterInterstitialAd.swift
+++ b/Source/AdMobAdapterInterstitialAd.swift
@@ -1,14 +1,7 @@
 // Copyright 2022-2023 Chartboost, Inc.
-// 
+//
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-
-//
-// AdMobAdapterInterstitialAd.swift
-// ChartboostMediationAdapterAdMob
-//
-// Created by Alex Rice on 10/02/22
-//
 
 import ChartboostMediationSDK
 import Foundation

--- a/Source/AdMobAdapterRewardedAd.swift
+++ b/Source/AdMobAdapterRewardedAd.swift
@@ -1,14 +1,7 @@
 // Copyright 2022-2023 Chartboost, Inc.
-// 
+//
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-
-//
-// AdMobAdapterRewardedAd.swift
-// ChartboostMediationAdapterAdMob
-//
-// Created by Alex Rice on 10/02/22
-//
 
 import ChartboostMediationSDK
 import Foundation


### PR DESCRIPTION
I'm working on a github action that would auto-generate PRs like this any time there were additional comment lines below the copyright header.

If there's no objection to removing the autogenerated "filename, project, created by" lines, I'll merge these changes in all adapter repos.