### PR TITLE
HB-5256: add platform_name to the networkExtras of all GADRequests

### DIFF
--- a/Source/AdMobAdapter.swift
+++ b/Source/AdMobAdapter.swift
@@ -39,7 +39,7 @@ final class AdMobAdapter: PartnerAdapter {
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.
     /// It includes a list of created `PartnerAd` instances. You may ignore this parameter if you don't need it.
     init(storage: PartnerAdapterStorage) {
-        // no-op
+        sharedExtras.additionalParameters = ["platform_name": "chartboost"]
     }
     
     /// Does any setup needed before beginning to load ads.


### PR DESCRIPTION
I don't think we have visibility into the networkExtras sent along with a GADRequest in Charles, but I verified that the networkExtras now contain `"platform_name": "chartboost"` by putting breakpoints in [AdMobAdapterBannerAd:38](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-admob/blob/a68c857517d404c2f30173170d206c6c4dfff808/Source/AdMobAdapterBannerAd.swift#L38), [AdMobAdapterInterstitialAd:25](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-admob/blob/a68c857517d404c2f30173170d206c6c4dfff808/Source/AdMobAdapterInterstitialAd.swift#L25), and [AdMobAdapterRewardedAd:25](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-admob/blob/a68c857517d404c2f30173170d206c6c4dfff808/Source/AdMobAdapterRewardedAd.swift#L25) and using the inspector to see that `adMobRequest._networkExtrasMap["GADExtras"]` contained the key value pair `"platform_name": "chartboost"`