### PR TITLE
Fix partner SDK version value

### DIFF
--- a/Source/AdMobAdapter.swift
+++ b/Source/AdMobAdapter.swift
@@ -17,8 +17,14 @@ enum GoogleStrings {
 }
 
 final class AdMobAdapter: PartnerAdapter {
+    
     /// The version of the partner SDK.
-    lazy var partnerSDKVersion = getGADVersionString()
+    var partnerSDKVersion: String {
+        // GADMobileAds SDK version is formatted like "afma-sdk-i-v9.14.0".
+        // We attempt to retrieve only the semantic version by stripping the prefix.
+        GADMobileAds.sharedInstance().sdkVersion
+            .replacingOccurrences(of: "afma-sdk-i-v", with: "")
+    }
     
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
@@ -213,9 +219,4 @@ final class AdMobAdapter: PartnerAdapter {
             return nil
         }
     }
-}
-
-func getGADVersionString() -> String {
-    let gadVersion = GADVersionNumber()
-    return "\(gadVersion.majorVersion).\(gadVersion.minorVersion).\(gadVersion.patchVersion)"
 }


### PR DESCRIPTION
It was always 0.0.0.
Note GADVersionNumber is a simple model and it does not represent the GoogleMobileAds SDK version.

I removed the "afma-sdk-i-v" prefix because it's what was done for 3.x, and I didn't want to risk causing trouble with backend at this point.
We can review in the future if passing the original string as is is okay.