### PR TITLE
[HB-6729] add privacy manifest

### DIFF
--- a/ChartboostMediationAdapterAdMob.podspec
+++ b/ChartboostMediationAdapterAdMob.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |spec|
   spec.module_name  = 'ChartboostMediationAdapterAdMob'
   spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-admob.git', :tag => spec.version }
   spec.source_files = 'Source/**/*.{swift}'
+  spec.resource_bundles = { 'ChartboostMediationAdapterAdMob' => ['PrivacyInfo.xcprivacy'] }
 
   # Minimum supported versions
   spec.swift_version         = '5.0'

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Source/AdMobAdapter.swift
+++ b/Source/AdMobAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/AdMobAdapterAd.swift
+++ b/Source/AdMobAdapterAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/AdMobAdapterBannerAd.swift
+++ b/Source/AdMobAdapterBannerAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/AdMobAdapterConfiguration.swift
+++ b/Source/AdMobAdapterConfiguration.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/AdMobAdapterInterstitialAd.swift
+++ b/Source/AdMobAdapterInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/AdMobAdapterRewardedAd.swift
+++ b/Source/AdMobAdapterRewardedAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/AdMobAdapterRewardedInterstitialAd.swift
+++ b/Source/AdMobAdapterRewardedInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Add a privacy manifest to declare `UserDefaults` usage (`NSPrivacyAccessedAPICategoryUserDefaults`).
![image](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-admob/assets/122156786/2bea3c28-018f-433e-b103-e34e010567d9)

There is no way to test this privacy manifest until it is publicly available, but we have until April 2023 to verify.