### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
           allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
           allow-warnings: true

--- a/Source/AdMobAdapter.swift
+++ b/Source/AdMobAdapter.swift
@@ -20,21 +20,26 @@ final class AdMobAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
     var partnerSDKVersion: String {
-        let versionNumber = GADMobileAds.sharedInstance().versionNumber
-        return "\(versionNumber.majorVersion).\(versionNumber.minorVersion).\(versionNumber.patchVersion)"
+        AdMobAdapterConfiguration.partnerSDKVersion
     }
     
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.11.2.0.0"
-    
+    var adapterVersion: String {
+        AdMobAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "admob"
-    
+    var partnerID: String {
+        AdMobAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "AdMob"
-    
+    var partnerDisplayName: String {
+        AdMobAdapterConfiguration.partnerDisplayName
+    }
+
     /// Parameters that should be included in all ad requests
     let sharedExtras = GADExtras()
     

--- a/Source/AdMobAdapterConfiguration.swift
+++ b/Source/AdMobAdapterConfiguration.swift
@@ -36,7 +36,7 @@ import os.log
         }
         set {
             GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = newValue
-            os_log(.debug, log: log, "AdMob SDK test device ID set to %{public}s", newValue ?? "nil")
+            os_log(.debug, log: log, "AdMob SDK test device IDs set to %{public}s", newValue ?? "nil")
         }
     }
 }

--- a/Source/AdMobAdapterConfiguration.swift
+++ b/Source/AdMobAdapterConfiguration.swift
@@ -10,6 +10,23 @@ import os.log
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class AdMobAdapterConfiguration: NSObject {
 
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        let versionNumber = GADMobileAds.sharedInstance().versionNumber
+        return "\(versionNumber.majorVersion).\(versionNumber.minorVersion).\(versionNumber.patchVersion)"
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.11.2.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "admob"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "AdMob"
+
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.admob", category: "Configuration")
 
     /// Google's identifier for your test device can be found in the console output from their SDK

--- a/Source/AdMobAdapterConfiguration.swift
+++ b/Source/AdMobAdapterConfiguration.swift
@@ -11,7 +11,7 @@ import os.log
 @objc public class AdMobAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         let versionNumber = GADMobileAds.sharedInstance().versionNumber
         return "\(versionNumber.majorVersion).\(versionNumber.minorVersion).\(versionNumber.patchVersion)"
     }
@@ -19,13 +19,13 @@ import os.log
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.11.2.0.0"
+    @objc public static let adapterVersion = "4.11.2.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "admob"
+    @objc public static let partnerID = "admob"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "AdMob"
+    @objc public static let partnerDisplayName = "AdMob"
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.admob", category: "Configuration")
 

--- a/Source/AdMobAdapterConfiguration.swift
+++ b/Source/AdMobAdapterConfiguration.swift
@@ -30,14 +30,13 @@ import os.log
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.admob", category: "Configuration")
 
     /// Google's identifier for your test device can be found in the console output from their SDK
-    @objc public static func setTestDeviceID(_ id: String?) {
-        if let id = id {
-            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = [id]
-        } else {
-            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = []
+    @objc public static var testDeviceIdentifiers: [String]? {
+        get {
+            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers
         }
-        if #available(iOS 12.0, *) {
-            os_log(.debug, log: log, "AdMob SDK test device ID set to %{public}s", id ?? "nil")
+        set {
+            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = newValue
+            os_log(.debug, log: log, "AdMob SDK test device ID set to %{public}s", newValue ?? "nil")
         }
     }
 }


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.