### PR TITLE
Early merge of main into release/5.x.x.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 - This version of the adapter has been certified with ChartboostMediationSDK 5.0.0.
 - This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.2.0.
 
+### 4.11.4.0.0
+- This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.4.0.
+
+### 4.11.3.0.0
+- This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.3.0.
+
 ### 4.11.2.0.0
 - This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.2.0.
 

--- a/ChartboostMediationAdapterAdMob.podspec
+++ b/ChartboostMediationAdapterAdMob.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterAdMob'
-  spec.version     = '5.11.2.0.0'
+  spec.version     = '5.11.4.0.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-admob'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 5.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'Google-Mobile-Ads-SDK', '~> 11.2.0'
+  spec.dependency 'Google-Mobile-Ads-SDK', '~> 11.4.0'
 
   # The partner network SDK is a static framework which requires the static_framework option.
   spec.static_framework = true

--- a/Source/AdMobAdapterConfiguration.swift
+++ b/Source/AdMobAdapterConfiguration.swift
@@ -19,7 +19,7 @@ import GoogleMobileAds
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc public static let adapterVersion = "4.11.2.0.0"
+    @objc public static let adapterVersion = "5.11.4.0.0"
 
     /// The partner's unique identifier.
     @objc public static let partnerID = "admob"


### PR DESCRIPTION
Merge of main into release/5.x.x.x.. Adapter version strings may or may not be up to date, they need to be changed once we finalize the partner version to release the 5.x adapters with anyway.